### PR TITLE
Implement credential storage and recall

### DIFF
--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -8,6 +8,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     libgtk-4-dev libcurl4-openssl-dev libssl-dev python3-gi gir1.2-gtk-4.0 \
     libsqlite3-dev libjansson-dev libprotobuf-c-dev adwaita-icon-theme \
     libmxml-dev pkg-config git wget xz-utils gnome-themes-extra \
+    libsecret-1-dev libsecret-1-0 libsecret-common libsecret-tools \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/appimage/assets/AppRun
+++ b/appimage/assets/AppRun
@@ -2,4 +2,8 @@
 
 # Allow app to operate detached from the game directory.
 export APPIMAGE_MODE_ENABLED=1
+
+# Make sure glib/libsecret schemas are read in.
+export XDG_DATA_DIRS="$APPDIR/usr/share:${XDG_DATA_DIRS:-}"
+
 exec "$APPDIR/usr/bin/tera_launcher_for_linux" "$@"

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(SQLite3 REQUIRED)
 pkg_check_modules(JANSSON REQUIRED jansson)
 pkg_check_modules(PROTOBUF_C REQUIRED libprotobuf-c)
 pkg_check_modules(GTK4 REQUIRED gtk4)
+pkg_check_modules(LIBSECRET REQUIRED libsecret-1)
 
 add_compile_definitions(HAVE_GLIB=1)
 
@@ -36,6 +37,7 @@ include_directories(
         ${CURL_INCLUDE_DIRS}
         ${JANSSON_INCLUDE_DIRS}
         ${GTK4_INCLUDE_DIRS}
+        ${LIBSECRET_INCLUDE_DIRS}
 )
 
 #############################################
@@ -85,6 +87,7 @@ add_executable(tera_launcher_for_linux
         ${CMAKE_CURRENT_SOURCE_DIR}/main.c
         ${CMAKE_CURRENT_SOURCE_DIR}/options_dialog.c
         ${CMAKE_CURRENT_SOURCE_DIR}/updater.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/auth.c
         ${GRESOURCE_C}  # the generated file
 )
 add_dependencies(tera_launcher_for_linux gtk_build_resources)
@@ -93,6 +96,7 @@ target_link_libraries(tera_launcher_for_linux PRIVATE
         ${JANSSON_LIBRARIES}
         ${CURL_LIBRARIES}
         ${OPENSSL_LIBRARIES}
+        ${LIBSECRET_LIBRARIES}
         SQLite::SQLite3
         terautils
 )

--- a/gui/auth.c
+++ b/gui/auth.c
@@ -1,0 +1,74 @@
+/** This program is free software. It comes without any warranty, to
+* the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details.
+ */
+
+#include "auth.h"
+#include <libsecret/secret.h>
+
+static const SecretSchema app_schema = {
+ "org.tera.launcher", SECRET_SCHEMA_NONE,
+ {
+  { "account", SECRET_SCHEMA_ATTRIBUTE_STRING },
+  {"service", SECRET_SCHEMA_ATTRIBUTE_STRING},
+  {nullptr, 0}
+ }
+};
+
+gboolean tl4l_store_account_password(const gchar *account, const char *password) {
+ GError *error = nullptr;
+ const gboolean ok = secret_password_store_sync(
+  &app_schema,
+  SECRET_COLLECTION_DEFAULT,
+  "Stored by TERA Launcher for Linux",
+  password,
+  nullptr,
+  &error,
+  "account", account,
+  "service", "TL4L",
+  nullptr
+  );
+
+ if (!ok) {
+  g_warning("Error storing Password: %s", error->message);
+  g_error_free(error);
+ }
+ return ok;
+}
+
+gchar *tl4l_lookup_account_password(const gchar *account) {
+ GError *error = nullptr;
+ gchar *password = secret_password_lookup_sync(
+  &app_schema,
+  nullptr,
+  &error,
+  "account", account,
+  "service", "TL4L",
+  nullptr);
+
+ if (error) {
+  g_warning("Error looking up password: %s", error->message);
+  g_error_free(error);
+  return nullptr;
+ }
+
+ return password;
+}
+
+void tl4l_clear_account_password(const gchar *account) {
+ GError *error = nullptr;;
+ secret_password_clear_sync(
+  &app_schema,
+  nullptr,
+  nullptr,
+  "account", account,
+  "service", "TL4L",
+  nullptr);
+
+ if (error) {
+  g_warning("Problem clearing account password for '%s': %s", account, error->message);
+  g_error_free(error);
+ }
+}

--- a/gui/auth.h
+++ b/gui/auth.h
@@ -1,0 +1,16 @@
+/** This program is free software. It comes without any warranty, to
+* the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details.
+ */
+
+#ifndef AUTH_H
+#define AUTH_H
+#include "globals.h"
+#include "shared_struct_defs.h"
+
+gboolean tl4l_store_account_password(const gchar *account, const char *password);
+gchar *tl4l_lookup_account_password(const gchar *account);
+void tl4l_clear_account_password(const gchar *account);
+#endif //AUTH_H

--- a/gui/globals.h
+++ b/gui/globals.h
@@ -14,6 +14,7 @@
 extern "C" {
 #endif
 
+extern char last_successful_login_username_global[FIXED_STRING_FIELD_SZ];
 extern char appdir_global[FIXED_STRING_FIELD_SZ];
 extern char game_lang_global[FIXED_STRING_FIELD_SZ];
 extern char wineprefix_global[FIXED_STRING_FIELD_SZ];
@@ -32,6 +33,7 @@ extern bool appimage_mode;
 extern bool use_gamemoderun;
 extern bool use_gamescope;
 extern bool use_tera_toolbox;
+extern bool save_login_info;
 
 #ifdef __cplusplus
 }

--- a/gui/gtk-assets/styles.css
+++ b/gui/gtk-assets/styles.css
@@ -68,3 +68,8 @@
     font-size: 16px;
     color: white;
 }
+
+.remember_me_checkbox {
+    font-size: 16px;
+    color: white;
+}

--- a/gui/main.c
+++ b/gui/main.c
@@ -1959,6 +1959,29 @@ static void on_login_clicked(GtkButton *btn, gpointer user_data) {
 
   LoginData temp = {0};
   if (do_login(username, password, &temp)) {
+    size_t required;
+    bool success;
+    if (gtk_check_button_get_active(GTK_CHECK_BUTTON(ld->login_store_checkbox))) {
+      save_login_info = true;
+      success = str_copy_formatted(last_successful_login_username_global,
+      &required, FIXED_STRING_FIELD_SZ, "%s", username);
+      if (success) {
+        if (!tl4l_store_account_password(username, password))
+          g_warning("Could not store password for account with username '%s'", username);
+        else
+          config_write_to_ini();
+      } else {
+        g_error("Failed to allocate %zu bytes for username in buffer of "
+          "size %zu bytes.",
+          required, FIXED_STRING_FIELD_SZ);
+      }
+    } else {
+      save_login_info = false;
+      memset(last_successful_login_username_global, 0, FIXED_STRING_FIELD_SZ);
+      tl4l_clear_account_password(username);
+      config_write_to_ini();
+    }
+
     // Store login data
     strncpy(ld->login_data.user_no, temp.user_no,
             sizeof(ld->login_data.user_no) - 1);
@@ -1968,8 +1991,7 @@ static void on_login_clicked(GtkButton *btn, gpointer user_data) {
             sizeof(ld->login_data.character_count) - 1);
 
     // Prepare user welcome label on patch screen.
-    size_t required;
-    const bool success = str_copy_formatted(ld->login_data.welcome_label_msg,
+    success = str_copy_formatted(ld->login_data.welcome_label_msg,
                                             &required, FIXED_STRING_FIELD_SZ,
                                             "Welcome, <b>%s!</b>", username);
     if (!success) {
@@ -2178,6 +2200,12 @@ static void activate(GtkApplication *app, gpointer user_data) {
     }
   }
 
+  // Reset stored username if user chose to no longer store login information.
+  if (!save_login_info && strlen(last_successful_login_username_global) > 0) {
+    tl4l_clear_account_password(last_successful_login_username_global);
+    memset(last_successful_login_username_global, 0, FIXED_STRING_FIELD_SZ);
+  }
+
   // Write loaded configuration (and any changes applied above).
   config_write_to_ini();
 
@@ -2251,6 +2279,17 @@ static void activate(GtkApplication *app, gpointer user_data) {
                             GTK_EVENT_CONTROLLER(ld->login_controller));
   gtk_widget_add_controller(ld->patch_overlay,
                             GTK_EVENT_CONTROLLER(ld->patch_controller));
+  gtk_check_button_set_active(GTK_CHECK_BUTTON(ld->login_store_checkbox), save_login_info);
+
+  if (strlen(last_successful_login_username_global) > 0 && save_login_info) {
+    gchar *password = tl4l_lookup_account_password(last_successful_login_username_global);
+    gtk_entry_buffer_set_text(gtk_entry_get_buffer(GTK_ENTRY(ld->user_entry)),
+      last_successful_login_username_global, -1);
+    if (password) {
+      gtk_entry_buffer_set_text(gtk_entry_get_buffer(GTK_ENTRY(ld->pass_entry)), password, -1);
+      g_free(password);
+    }
+  }
 
   // Show the main window
   gtk_widget_set_visible(ld->window, TRUE);

--- a/gui/main.c
+++ b/gui/main.c
@@ -73,6 +73,11 @@ struct CurlResponse {
 };
 
 /**
+ * @brief The username of the last successful login.
+ */
+char last_successful_login_username_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
  * @brief AppDir path, only used in when AppImage mode is enabled.
  */
 char appdir_global[FIXED_STRING_FIELD_SZ] = {0};
@@ -175,6 +180,11 @@ bool appimage_mode = false;
  * game itself. Turned off by default.
  */
 bool use_tera_toolbox = false;
+
+/**
+ * @brief If set to TRUE, attempt to store login info so it can be retrieved later.
+ */
+bool save_login_info = false;
 
 /**
  * @brief Used to store the final update thread message, if any, to update

--- a/gui/main.c
+++ b/gui/main.c
@@ -345,7 +345,6 @@ static bool do_login(const char *username, const char *password,
         "Failed to allocate %zu bytes for postfields into buffer of %zu bytes.",
         required, FIXED_STRING_FIELD_SZ);
   }
-  g_message("Fields being sent: %s", postfields);
 
   // Set cURL options
   curl_easy_setopt(curl, CURLOPT_URL, auth_url_global);
@@ -354,7 +353,6 @@ static bool do_login(const char *username, const char *password,
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
-  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   // Perform the request
   CURLcode res = curl_easy_perform(curl);

--- a/gui/main.c
+++ b/gui/main.c
@@ -543,6 +543,15 @@ static GtkWidget *create_login_overlay(LauncherData *ld) {
   gtk_widget_add_css_class(ld->pass_entry, "img_textbox");
   gtk_overlay_add_overlay(GTK_OVERLAY(overlay), ld->pass_entry);
 
+  // Toggle to store login info or not.
+  ld->login_store_checkbox = gtk_check_button_new_with_label("Remember Login?");
+  gtk_widget_set_halign(ld->login_store_checkbox, GTK_ALIGN_START);
+  gtk_widget_set_valign(ld->login_store_checkbox, GTK_ALIGN_END);
+  gtk_widget_set_margin_start(ld->login_store_checkbox, 68);
+  gtk_widget_set_margin_bottom(ld->login_store_checkbox, 264);
+  gtk_widget_add_css_class(ld->login_store_checkbox, "remember_me_checkbox");
+  gtk_overlay_add_overlay(GTK_OVERLAY(overlay), ld->login_store_checkbox);
+
   // Login Button
   GdkTexture *login_sub =
       load_subimage("/com/tera/launcher/btn-auth.png", 0, 0, 224, 69);

--- a/gui/main.c
+++ b/gui/main.c
@@ -5,7 +5,7 @@
  * http://www.wtfpl.net/ for more details.
  */
 
-#include "shared_struct_defs.h"
+#include "auth.h"
 #include "updater.h"
 #include <curl/curl.h>
 #include <gdk/gdk.h>

--- a/gui/main.c
+++ b/gui/main.c
@@ -389,9 +389,6 @@ static bool do_login(const char *username, const char *password,
               out->user_no[sizeof(out->user_no) - 1] = '\0';
               out->auth_key[sizeof(out->auth_key) - 1] = '\0';
               out->character_count[sizeof(out->character_count) - 1] = '\0';
-
-              g_message("Login success: user_no=%s, AuthKey=%s, CharCount=%s",
-                        out->user_no, out->auth_key, out->character_count);
               success = true;
             } else {
               g_warning("Invalid JSON structure for login data.");

--- a/gui/options_dialog.c
+++ b/gui/options_dialog.c
@@ -757,6 +757,7 @@ void config_read_from_ini(void) {
   READ_STRING_KEY("wine_base_dir", wine_base_dir_global);
   READ_STRING_KEY("tera_toolbox_path", tera_toolbox_path_global);
   READ_STRING_KEY("gamescope_args", gamescope_args_global);
+  READ_STRING_KEY("last_successful_login_username", last_successful_login_username_global);
 
 #undef READ_STRING_KEY
   /* If wine_base_dir is unset in AppImage mode or contains a tmp path,
@@ -799,6 +800,7 @@ void config_read_from_ini(void) {
   READ_BOOL_KEY("use_gamemoderun", use_gamemoderun);
   READ_BOOL_KEY("use_gamescope", use_gamescope);
   READ_BOOL_KEY("use_tera_toolbox", use_tera_toolbox);
+  READ_BOOL_KEY("save_login_info", save_login_info);
 
 #undef READ_BOOL_KEY
 
@@ -842,7 +844,7 @@ void config_write_to_ini(void) {
   WRITE_STRING_KEY("gameprefix", gameprefix_global);
   WRITE_STRING_KEY("tera_toolbox_path", tera_toolbox_path_global);
   WRITE_STRING_KEY("gamescope_args", gamescope_args_global);
-
+  WRITE_STRING_KEY("last_successful_login_username", last_successful_login_username_global);
 #undef WRITE_STRING_KEY
 
   // Write boolean values (always written)
@@ -851,6 +853,7 @@ void config_write_to_ini(void) {
   g_key_file_set_boolean(keyfile, "Settings", "use_gamescope", use_gamescope);
   g_key_file_set_boolean(keyfile, "Settings", "use_tera_toolbox",
                          use_tera_toolbox);
+  g_key_file_set_boolean(keyfile, "Settings", "save_login_info", save_login_info);
 
   // Save to file
   gsize length = 0;

--- a/gui/shared_struct_defs.h
+++ b/gui/shared_struct_defs.h
@@ -42,6 +42,7 @@ typedef struct {
   GtkWindowHandle *login_window_handle;
   GtkWidget *user_entry;
   GtkWidget *pass_entry;
+  GtkWidget *login_store_checkbox;
   GtkWidget *login_btn;
   GtkWidget *close_login_btn;
 


### PR DESCRIPTION
This adds support for saving, recalling and clearing saved login credentials at the login screen. We use libsecret for this.

Remaining work to be done:
- Verify this works as expected on the Steam Deck without being in desktop mode (unsure how the secrets API holds up when not opening app from Plasma)
- Update documentation to indicate additional dependency

After this and the torrent feature are implemented, this will need to be reworked for asynchronous use. That will be part of the big refactor.

Relates to #4 