### PR TITLE
Support plaintext password storage

### DIFF
--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:24.04
 # Install system packages and build dependencies
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     build-essential cmake wine libwine-dev squashfs-tools \
-    python3 python3-pip python3-setuptools file cabextract p7zip-full unzip \
+    python3 python3-pip python3-setuptools file cabextract p7zip-full unzip zstd \
     libgtk-4-dev libcurl4-openssl-dev libssl-dev python3-gi gir1.2-gtk-4.0 \
     libsqlite3-dev libjansson-dev libprotobuf-c-dev adwaita-icon-theme \
     libmxml-dev pkg-config git wget xz-utils gnome-themes-extra \

--- a/appimage/assets/AppRun
+++ b/appimage/assets/AppRun
@@ -3,7 +3,7 @@
 # Allow app to operate detached from the game directory.
 export APPIMAGE_MODE_ENABLED=1
 
-# Make sure glib/libsecret schemas are read in.
 export XDG_DATA_DIRS="$APPDIR/usr/share:${XDG_DATA_DIRS:-}"
-
+export PATH="$APPDIR/usr/bin:${PATH:-}"
+export LD_LIBRARY_PATH="$APPDIR/usr/lib:${LD_LIBRARY_PATH:-}"
 exec "$APPDIR/usr/bin/tera_launcher_for_linux" "$@"

--- a/appimage/assets/tera-launcher.desktop
+++ b/appimage/assets/tera-launcher.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=TERA Launcher for Linux
-Exec=env APPIMAGE_MODE_ENABLED=1 ./AppRun
+Exec=./AppRun
 Icon=tera-launcher
 Type=Application
 Categories=Game;

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -13,11 +13,13 @@ GE_PROTON_URL="${GE_PROTON_URL:-https://github.com/GloriousEggroll/proton-ge-cus
 GE_PROTON_DEST="ge-proton"
 SCRATCH_DIR="/scratch"
 BUILD_DIR="${SCRATCH_DIR}/build"
-APPDIR="$(pwd)/AppDir"
-LINUXDEPLOY="linuxdeploy-x86_64.AppImage"
-PLUGIN_GTK_SH="linuxdeploy-plugin-gtk.sh"
-PLUGIN_GTK_BIN="linuxdeploy-plugin-gtk"
-APPIMAGETOOL="appimagetool-x86_64.AppImage"
+APPDIR="${SCRATCH_DIR}/AppDir"
+TOOLS_DIR="${SCRATCH_DIR}/tools"
+
+# External tooling paths (will live outside AppDir)
+LINUXDEPLOY="${TOOLS_DIR}/linuxdeploy-x86_64.AppImage"
+PLUGIN_GTK="${TOOLS_DIR}/linuxdeploy-plugin-gtk"
+APPIMAGETOOL="${TOOLS_DIR}/appimagetool-x86_64.AppImage"
 
 #========================================
 # Helpers
@@ -34,34 +36,18 @@ EOF
   exit 0
 }
 
-log() {
-  printf "[INFO] %s\n" "$*"
-}
-
-error() {
-  printf "[ERROR] %s\n" "$*" >&2
-  exit 1
-}
+log() { printf "[INFO] %s\n" "$*"; }
+error() { printf "[ERROR] %s\n" "$*" >&2; exit 1; }
 
 #========================================
 # Argument parsing
 #========================================
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h|--help)
-      usage
-      ;;
-    -c|--clone)
-      CLONE_REPO=1
-      shift
-      ;;
-    -b|--branch)
-      BRANCH="${2:-}"
-      shift 2
-      ;;
-    *)
-      error "Unknown option: $1"
-      ;;
+    -h|--help) usage;;
+    -c|--clone) CLONE_REPO=1; shift;;
+    -b|--branch) BRANCH="${2:-}"; shift 2;;
+    *) error "Unknown option: $1";;
   esac
 done
 
@@ -74,26 +60,30 @@ for cmd in "${dependencies[@]}"; do
 done
 
 #========================================
+# Prepare directories
+#========================================
+prepare_dirs() {
+  log "Preparing build and tool directories"
+  rm -rf "$BUILD_DIR" "$TOOLS_DIR"
+  mkdir -p "$BUILD_DIR" "$TOOLS_DIR" "$APPDIR/usr/bin" "$APPDIR/usr/lib"
+}
+
+#========================================
 # Prepare source
 #========================================
 prepare_source() {
   if [[ "$CLONE_REPO" == "1" ]]; then
     [[ -n "$REPO_URL" ]] || error "CLONE_REPO is set but REPO_URL is empty"
-    SRC_DIR="src-repo"
-    rm -rf "$SRC_DIR"
+    SRC_DIR="src-repo"; rm -rf "$SRC_DIR"
     log "Cloning $REPO_URL into $SRC_DIR"
-    git clone "$REPO_URL" "$SRC_DIR"
-    cd "$SRC_DIR"
-    git fetch --all --prune
-    git checkout "$BRANCH"
+    git clone "$REPO_URL" "$SRC_DIR"; cd "$SRC_DIR"
+    git fetch --all --prune; git checkout "$BRANCH"
   else
-    SRC_DIR=".."
-    cd "$SRC_DIR"
+    SRC_DIR=".."; cd "$SRC_DIR" || true
     git config --global --add safe.directory /src || true
   fi
   [[ -d ".git" ]] || error "No git repository in $SRC_DIR"
-  SRC_DIR="$(pwd)"
-  log "Source directory: $SRC_DIR"
+  SRC_DIR="$(pwd)"; log "Source directory: $SRC_DIR"
 }
 
 #========================================
@@ -101,39 +91,20 @@ prepare_source() {
 #========================================
 build_launcher() {
   log "Building launcher in $BUILD_DIR"
-  rm -rf "$BUILD_DIR"
-  mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
+  cd "$BUILD_DIR"
   cmake "$SRC_DIR" -DCMAKE_BUILD_TYPE=Release
   cmake --build . --parallel "$(nproc)"
 }
 
 #========================================
-# Set up AppDir structure
-#========================================
-prepare_appdir() {
-  log "Preparing AppDir at $APPDIR"
-  rm -rf "$APPDIR"
-  mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/lib"
-}
-
-#========================================
-# Copy binaries and assets
+# Copy launcher binaries and assets
 #========================================
 copy_binaries_and_assets() {
   log "Copying launcher binaries and assets"
   cp "$BUILD_DIR/bin/"* "$APPDIR/usr/bin/"
-
-  copy_tool() {
-    local tool="$1"
-    log "Including $tool"
-    cp "$(command -v $tool)" "$APPDIR/usr/bin/"
-  }
-
-  for t in cabextract unzip 7z 7za 7zr sh bash; do
-    copy_tool "$t"
-  done
+  copy_tool() { local tool="$1"; log "Including system tool: $tool"; cp "$(command -v $tool)" "$APPDIR/usr/bin/"; }
+  for t in cabextract unzip 7z 7za 7zr pzstd unzstd zstd zstdcat zstdgrep zstdless zstdmt sh bash; do copy_tool "$t"; done
   cp -r /usr/lib/7zip "$APPDIR/usr/lib/"
-
   for asset in tera-launcher.desktop tera-launcher.png AppRun; do
     cp "$SRC_DIR/appimage/assets/$asset" "$APPDIR/$asset"
     [[ "$asset" == "AppRun" ]] && chmod +x "$APPDIR/AppRun"
@@ -141,22 +112,21 @@ copy_binaries_and_assets() {
 }
 
 #========================================
-# Download common tools
+# Download external tools
 #========================================
 download_tools() {
-  log "Downloading Winetricks"
-  wget -q -O winetricks \
-    https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
-  chmod +x winetricks
-  mv winetricks "$APPDIR/usr/bin/"
+  log "Downloading Winetricks into AppDir"
+  wget -q -O winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
+  chmod +x winetricks; mv winetricks "$APPDIR/usr/bin/"
 
-  log "Fetching linuxdeploy and GTK plugin"
-  wget -q -O "$LINUXDEPLOY" \
-    "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/$LINUXDEPLOY"
-  wget -q -O "$PLUGIN_GTK_SH" \
-    "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
-  chmod +x "$LINUXDEPLOY" "$PLUGIN_GTK_SH"
-  mv "$PLUGIN_GTK_SH" "$PLUGIN_GTK_BIN"
+  log "Downloading linuxdeploy and GTK plugin"
+  wget -q -O "$LINUXDEPLOY" "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/$(basename $LINUXDEPLOY)"
+  wget -q -O "$PLUGIN_GTK" "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
+  chmod +x "$LINUXDEPLOY" "$PLUGIN_GTK"
+
+  log "Downloading appimagetool"
+  wget -q -O "$APPIMAGETOOL" "https://github.com/AppImage/AppImageKit/releases/download/continuous/$(basename $APPIMAGETOOL)"
+  chmod +x "$APPIMAGETOOL"
 }
 
 #========================================
@@ -164,56 +134,46 @@ download_tools() {
 #========================================
 package_appimage() {
   log "Packaging initial AppImage"
-  ./$LINUXDEPLOY --appimage-extract
-
-  mapfile -t execs < <(
-    find "$APPDIR/usr/bin" -maxdepth 1 -type f -executable \
-      ! -name "stub_launcher.exe*" ! -name "winetricks" ! -name "7z*"
-  )
-
-  args=(--appdir "$APPDIR" -d "$APPDIR/tera-launcher.desktop"
-        -i "$APPDIR/tera-launcher.png" --plugin gtk --output appimage)
-  for bin in "${execs[@]}"; do
-    args+=( -e "$bin" )
-  done
-
+  LDP_EXTRACT="$BUILD_DIR/linuxdeploy-squashfs"
+  rm -rf "$LDP_EXTRACT"; "$LINUXDEPLOY" --appimage-extract; mv squashfs-root "$LDP_EXTRACT"
+  cp "$PLUGIN_GTK" "$LDP_EXTRACT/"
+  mapfile -t execs < <(find "$APPDIR/usr/bin" -maxdepth 1 -type f -executable ! -name "stub_launcher.exe*" ! -name "winetricks" ! -name "7z*" ! -name "unzstd" ! -name "zstdcat" ! -name "zstdmt" ! -name "zstdless" ! -name "zstdgrep")
+  args=(--appdir "$APPDIR" -d "$APPDIR/tera-launcher.desktop" -i "$APPDIR/tera-launcher.png" --plugin gtk --output appimage)
+  for bin in "${execs[@]}"; do args+=( -e "$bin" ); done
   printf "Will bundle executables: %s\n" "${execs[*]}"
-  ./squashfs-root/AppRun "${args[@]}"
+  pushd "$LDP_EXTRACT" >/dev/null; ./AppRun "${args[@]}"; GENERATED=$(ls *.AppImage | head -n1) || error "No AppImage generated"; mv "$GENERATED" "$BUILD_DIR/"; log "Moved $GENERATED to $BUILD_DIR"; popd >/dev/null; rm -rf "$LDP_EXTRACT"
 }
 
 #========================================
-# Inject GE-Proton
+# Inject GE-Proton cleanly
 #========================================
 inject_ge_proton() {
-  log "Downloading GE-Proton ($GE_PROTON_URL)"
-  wget -q -O "$GE_PROTON_TARBALL" "$GE_PROTON_URL"
-
+  log "Downloading GE-Proton"
+  cd "$BUILD_DIR"; wget -q -O "$GE_PROTON_TARBALL" "$GE_PROTON_URL"
   mkdir -p "$APPDIR/usr/lib/$GE_PROTON_DEST"
-  tar -xf "$GE_PROTON_TARBALL" --strip-components=1 -C "$APPDIR/usr/lib/$GE_PROTON_DEST"
-  rm "$GE_PROTON_TARBALL"
+  tar -xf "$GE_PROTON_TARBALL" --strip-components=1 -C "$APPDIR/usr/lib/$GE_PROTON_DEST"; rm "$GE_PROTON_TARBALL"
 
-  APPIMAGE_FILE=$(ls ./*-x86_64.AppImage | head -n1)
-  log "Injecting GE-Proton into $APPIMAGE_FILE"
+  APPIMAGE="$(ls "$BUILD_DIR"/*-x86_64.AppImage | head -n1)"
+  [[ -f "$APPIMAGE" ]] || error "No AppImage to inject"
+  log "Injecting into $(basename "$APPIMAGE")"
 
-  export APPIMAGE_EXTRACT_AND_RUN=1
-  ./"$APPIMAGE_FILE" --appimage-extract
-  unset APPIMAGE_EXTRACT_AND_RUN
+  INJ_EXTRACT="$BUILD_DIR/inject-squashfs"
+  rm -rf "$INJ_EXTRACT"; mkdir -p "$INJ_EXTRACT"
+  (cd "$INJ_EXTRACT"; export APPIMAGE_EXTRACT_AND_RUN=1; "$APPIMAGE" --appimage-extract; unset APPIMAGE_EXTRACT_AND_RUN)
+  cp -r "$APPDIR/usr/lib/$GE_PROTON_DEST" "$INJ_EXTRACT/squashfs-root/usr/lib/"
 
-  [[ -d squashfs-root ]] || error "Extraction failed"
-  cp -r "$APPDIR/usr/lib/$GE_PROTON_DEST" squashfs-root/usr/lib/
-
-  log "Fetching appimagetool"
-  wget -q -O "$APPIMAGETOOL" \
-    "https://github.com/AppImage/AppImageKit/releases/download/continuous/$APPIMAGETOOL"
-  chmod +x "$APPIMAGETOOL"
+  # Use extracted appimagetool run to avoid FUSE
+  AI_EXTRACT="$TOOLS_DIR/appimagetool-squashfs"
+  rm -rf "$AI_EXTRACT"; "$APPIMAGETOOL" --appimage-extract; mv squashfs-root "$AI_EXTRACT"
+  AI_RUN="$AI_EXTRACT/AppRun"
 
   log "Re-packing AppImage"
-  export APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64
-  ./$APPIMAGETOOL squashfs-root "$APPIMAGE_FILE"
-  unset APPIMAGE_EXTRACT_AND_RUN ARCH
+  ARCH=x86_64 "$AI_RUN" "$INJ_EXTRACT/squashfs-root" "$APPIMAGE"
 
-  mv "$APPIMAGE_FILE" "$SRC_DIR/"
-  log "Done: $APPIMAGE_FILE moved to $SRC_DIR"
+  mv "$APPIMAGE" "$SRC_DIR/"
+  log "Done: moved $(basename "$APPIMAGE") to $SRC_DIR"
+
+  rm -rf "$INJ_EXTRACT"
 }
 
 #========================================
@@ -221,13 +181,7 @@ inject_ge_proton() {
 #========================================
 main() {
   log "Settings: CLONE_REPO=$CLONE_REPO, BRANCH=$BRANCH, GE_PROTON_VERSION=$GE_PROTON_VERSION"
-  prepare_source
-  build_launcher
-  prepare_appdir
-  copy_binaries_and_assets
-  download_tools
-  package_appimage
-  inject_ge_proton
+  prepare_dirs; prepare_source; build_launcher; copy_binaries_and_assets; download_tools; package_appimage; inject_ge_proton
 }
 
 main "$@"

--- a/gui/auth.c
+++ b/gui/auth.c
@@ -1,5 +1,5 @@
 /** This program is free software. It comes without any warranty, to
-* the extent permitted by applicable law. You can redistribute it
+ * the extent permitted by applicable law. You can redistribute it
  * and/or modify it under the terms of the Do What The Fuck You Want
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://www.wtfpl.net/ for more details.
@@ -9,66 +9,51 @@
 #include <libsecret/secret.h>
 
 static const SecretSchema app_schema = {
- "org.tera.launcher", SECRET_SCHEMA_NONE,
- {
-  { "account", SECRET_SCHEMA_ATTRIBUTE_STRING },
-  {"service", SECRET_SCHEMA_ATTRIBUTE_STRING},
-  {nullptr, 0}
- }
-};
+    "org.tera.launcher",
+    SECRET_SCHEMA_NONE,
+    {{"account", SECRET_SCHEMA_ATTRIBUTE_STRING},
+     {"service", SECRET_SCHEMA_ATTRIBUTE_STRING},
+     {nullptr, 0}}};
 
-gboolean tl4l_store_account_password(const gchar *account, const char *password) {
- GError *error = nullptr;
- const gboolean ok = secret_password_store_sync(
-  &app_schema,
-  SECRET_COLLECTION_DEFAULT,
-  "Stored by TERA Launcher for Linux",
-  password,
-  nullptr,
-  &error,
-  "account", account,
-  "service", "TL4L",
-  nullptr
-  );
+gboolean tl4l_store_account_password(const gchar *account,
+                                     const char *password) {
+  GError *error = nullptr;
+  const gboolean ok = secret_password_store_sync(
+      &app_schema, SECRET_COLLECTION_DEFAULT,
+      "Stored by TERA Launcher for Linux", password, nullptr, &error, "account",
+      account, "service", "TL4L", nullptr);
 
- if (!ok) {
-  g_warning("Error storing Password: %s", error->message);
-  g_error_free(error);
- }
- return ok;
+  if (!ok) {
+    g_warning("Error storing Password: %s", error->message);
+    g_error_free(error);
+  }
+  return ok;
 }
 
 gchar *tl4l_lookup_account_password(const gchar *account) {
- GError *error = nullptr;
- gchar *password = secret_password_lookup_sync(
-  &app_schema,
-  nullptr,
-  &error,
-  "account", account,
-  "service", "TL4L",
-  nullptr);
+  GError *error = nullptr;
+  gchar *password =
+      secret_password_lookup_sync(&app_schema, nullptr, &error, "account",
+                                  account, "service", "TL4L", nullptr);
 
- if (error) {
-  g_warning("Error looking up password: %s", error->message);
-  g_error_free(error);
-  return nullptr;
- }
+  if (error) {
+    g_warning("Error looking up password: %s", error->message);
+    g_error_free(error);
+    return nullptr;
+  }
 
- return password;
+  return password;
 }
 
 void tl4l_clear_account_password(const gchar *account) {
- GError *error = nullptr;;
- secret_password_clear_sync(
-  &app_schema,
-  nullptr,
-  nullptr,
-  "account", account,
-  "service", "TL4L",
-  nullptr);
+  GError *error = nullptr;
+  ;
+  secret_password_clear_sync(&app_schema, nullptr, nullptr, "account", account,
+                             "service", "TL4L", nullptr);
 
- if (error) {
-  g_warning("Problem clearing account password for '%s': %s", account, error->message);
-  g_error_free(error);
- }
+  if (error) {
+    g_warning("Problem clearing account password for '%s': %s", account,
+              error->message);
+    g_error_free(error);
+  }
 }

--- a/gui/auth.h
+++ b/gui/auth.h
@@ -1,5 +1,5 @@
 /** This program is free software. It comes without any warranty, to
-* the extent permitted by applicable law. You can redistribute it
+ * the extent permitted by applicable law. You can redistribute it
  * and/or modify it under the terms of the Do What The Fuck You Want
  * To Public License, Version 2, as published by Sam Hocevar. See
  * http://www.wtfpl.net/ for more details.
@@ -10,7 +10,8 @@
 #include "globals.h"
 #include "shared_struct_defs.h"
 
-gboolean tl4l_store_account_password(const gchar *account, const char *password);
+gboolean tl4l_store_account_password(const gchar *account,
+                                     const char *password);
 gchar *tl4l_lookup_account_password(const gchar *account);
 void tl4l_clear_account_password(const gchar *account);
-#endif //AUTH_H
+#endif // AUTH_H

--- a/gui/globals.h
+++ b/gui/globals.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 extern char last_successful_login_username_global[FIXED_STRING_FIELD_SZ];
+extern char last_successful_login_password_global[FIXED_STRING_FIELD_SZ];
 extern char appdir_global[FIXED_STRING_FIELD_SZ];
 extern char game_lang_global[FIXED_STRING_FIELD_SZ];
 extern char wineprefix_global[FIXED_STRING_FIELD_SZ];
@@ -34,6 +35,7 @@ extern bool use_gamemoderun;
 extern bool use_gamescope;
 extern bool use_tera_toolbox;
 extern bool save_login_info;
+extern bool plaintext_login_info_storage;
 
 #ifdef __cplusplus
 }

--- a/gui/main.c
+++ b/gui/main.c
@@ -1407,8 +1407,6 @@ static gchar **build_wine_environment(const gchar *custom_wine_dir,
                                       const bool enable_wsi_fix,
                                       gchar **wine_path) {
   gchar **envp = g_get_environ();
-
-  /* ── 1. Locate the Wine binary ──────────────────────────────────────── */
   gchar *resolved_wine = nullptr;
 
   if (custom_wine_dir && *custom_wine_dir) {

--- a/gui/main.c
+++ b/gui/main.c
@@ -182,7 +182,8 @@ bool appimage_mode = false;
 bool use_tera_toolbox = false;
 
 /**
- * @brief If set to TRUE, attempt to store login info so it can be retrieved later.
+ * @brief If set to TRUE, attempt to store login info so it can be retrieved
+ * later.
  */
 bool save_login_info = false;
 
@@ -1961,19 +1962,22 @@ static void on_login_clicked(GtkButton *btn, gpointer user_data) {
   if (do_login(username, password, &temp)) {
     size_t required;
     bool success;
-    if (gtk_check_button_get_active(GTK_CHECK_BUTTON(ld->login_store_checkbox))) {
+    if (gtk_check_button_get_active(
+            GTK_CHECK_BUTTON(ld->login_store_checkbox))) {
       save_login_info = true;
-      success = str_copy_formatted(last_successful_login_username_global,
-      &required, FIXED_STRING_FIELD_SZ, "%s", username);
+      success =
+          str_copy_formatted(last_successful_login_username_global, &required,
+                             FIXED_STRING_FIELD_SZ, "%s", username);
       if (success) {
         if (!tl4l_store_account_password(username, password))
-          g_warning("Could not store password for account with username '%s'", username);
+          g_warning("Could not store password for account with username '%s'",
+                    username);
         else
           config_write_to_ini();
       } else {
         g_error("Failed to allocate %zu bytes for username in buffer of "
-          "size %zu bytes.",
-          required, FIXED_STRING_FIELD_SZ);
+                "size %zu bytes.",
+                required, FIXED_STRING_FIELD_SZ);
       }
     } else {
       save_login_info = false;
@@ -1991,9 +1995,9 @@ static void on_login_clicked(GtkButton *btn, gpointer user_data) {
             sizeof(ld->login_data.character_count) - 1);
 
     // Prepare user welcome label on patch screen.
-    success = str_copy_formatted(ld->login_data.welcome_label_msg,
-                                            &required, FIXED_STRING_FIELD_SZ,
-                                            "Welcome, <b>%s!</b>", username);
+    success = str_copy_formatted(ld->login_data.welcome_label_msg, &required,
+                                 FIXED_STRING_FIELD_SZ, "Welcome, <b>%s!</b>",
+                                 username);
     if (!success) {
       g_error("Failed to allocate %zu bytes for welcome string in buffer of "
               "size %zu bytes.",
@@ -2279,14 +2283,17 @@ static void activate(GtkApplication *app, gpointer user_data) {
                             GTK_EVENT_CONTROLLER(ld->login_controller));
   gtk_widget_add_controller(ld->patch_overlay,
                             GTK_EVENT_CONTROLLER(ld->patch_controller));
-  gtk_check_button_set_active(GTK_CHECK_BUTTON(ld->login_store_checkbox), save_login_info);
+  gtk_check_button_set_active(GTK_CHECK_BUTTON(ld->login_store_checkbox),
+                              save_login_info);
 
   if (strlen(last_successful_login_username_global) > 0 && save_login_info) {
-    gchar *password = tl4l_lookup_account_password(last_successful_login_username_global);
+    gchar *password =
+        tl4l_lookup_account_password(last_successful_login_username_global);
     gtk_entry_buffer_set_text(gtk_entry_get_buffer(GTK_ENTRY(ld->user_entry)),
-      last_successful_login_username_global, -1);
+                              last_successful_login_username_global, -1);
     if (password) {
-      gtk_entry_buffer_set_text(gtk_entry_get_buffer(GTK_ENTRY(ld->pass_entry)), password, -1);
+      gtk_entry_buffer_set_text(gtk_entry_get_buffer(GTK_ENTRY(ld->pass_entry)),
+                                password, -1);
       g_free(password);
     }
   }

--- a/gui/main.c
+++ b/gui/main.c
@@ -78,6 +78,12 @@ struct CurlResponse {
 char last_successful_login_username_global[FIXED_STRING_FIELD_SZ] = {0};
 
 /**
+ * @brief The password of the last successful login. Note this is only populated
+ * when plaintext password storage is enabled.
+ */
+char last_successful_login_password_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
  * @brief AppDir path, only used in when AppImage mode is enabled.
  */
 char appdir_global[FIXED_STRING_FIELD_SZ] = {0};
@@ -186,6 +192,12 @@ bool use_tera_toolbox = false;
  * later.
  */
 bool save_login_info = false;
+
+/**
+ * @brief If set to TRUE, read and write login info when user requests to store
+ * it to plain text.
+ */
+bool plaintext_login_info_storage = false;
 
 /**
  * @brief Used to store the final update thread message, if any, to update

--- a/gui/options_dialog.c
+++ b/gui/options_dialog.c
@@ -759,6 +759,8 @@ void config_read_from_ini(void) {
   READ_STRING_KEY("gamescope_args", gamescope_args_global);
   READ_STRING_KEY("last_successful_login_username",
                   last_successful_login_username_global);
+  READ_STRING_KEY("last_successful_login_password",
+                  last_successful_login_password_global);
 
 #undef READ_STRING_KEY
   /* If wine_base_dir is unset in AppImage mode or contains a tmp path,
@@ -848,6 +850,12 @@ void config_write_to_ini(void) {
   WRITE_STRING_KEY("last_successful_login_username",
                    last_successful_login_username_global);
 #undef WRITE_STRING_KEY
+
+  // We do not write the password to the config file unless plain text storage
+  // is enabled.
+  if (last_successful_login_password_global && plaintext_login_info_storage)
+    g_key_file_set_string(keyfile, "Settings", "last_successful_login_password",
+                          last_successful_login_password_global);
 
   // Write boolean values (always written)
   g_key_file_set_boolean(keyfile, "Settings", "use_gamemoderun",

--- a/gui/options_dialog.c
+++ b/gui/options_dialog.c
@@ -770,7 +770,7 @@ void config_read_from_ini(void) {
     size_t needed;
     if (!str_copy_formatted(wine_base_dir_global, &needed,
                             FIXED_STRING_FIELD_SZ, "%s/%s", appdir_global,
-                            "/usr/lib/ge-proton/files")) {
+                            "usr/lib/ge-proton/files")) {
       g_error("Unable to specify path to bundled GE-Proton runtime. Cannot "
               "continue.");
     }

--- a/gui/options_dialog.c
+++ b/gui/options_dialog.c
@@ -757,7 +757,8 @@ void config_read_from_ini(void) {
   READ_STRING_KEY("wine_base_dir", wine_base_dir_global);
   READ_STRING_KEY("tera_toolbox_path", tera_toolbox_path_global);
   READ_STRING_KEY("gamescope_args", gamescope_args_global);
-  READ_STRING_KEY("last_successful_login_username", last_successful_login_username_global);
+  READ_STRING_KEY("last_successful_login_username",
+                  last_successful_login_username_global);
 
 #undef READ_STRING_KEY
   /* If wine_base_dir is unset in AppImage mode or contains a tmp path,
@@ -844,7 +845,8 @@ void config_write_to_ini(void) {
   WRITE_STRING_KEY("gameprefix", gameprefix_global);
   WRITE_STRING_KEY("tera_toolbox_path", tera_toolbox_path_global);
   WRITE_STRING_KEY("gamescope_args", gamescope_args_global);
-  WRITE_STRING_KEY("last_successful_login_username", last_successful_login_username_global);
+  WRITE_STRING_KEY("last_successful_login_username",
+                   last_successful_login_username_global);
 #undef WRITE_STRING_KEY
 
   // Write boolean values (always written)
@@ -853,7 +855,8 @@ void config_write_to_ini(void) {
   g_key_file_set_boolean(keyfile, "Settings", "use_gamescope", use_gamescope);
   g_key_file_set_boolean(keyfile, "Settings", "use_tera_toolbox",
                          use_tera_toolbox);
-  g_key_file_set_boolean(keyfile, "Settings", "save_login_info", save_login_info);
+  g_key_file_set_boolean(keyfile, "Settings", "save_login_info",
+                         save_login_info);
 
   // Save to file
   gsize length = 0;


### PR DESCRIPTION
As much as I hate to have to offer this, SteamOS when not on the Plasma Desktop has no built in secrets interface for libsecret, leaving the user to either set up a service on their own to fill in the gaps or not be able to store their login info.

I will add an ENV toggle -- `TL4L_ENABLE_PLAINTEXT_PASSWORD_STORAGE=1` -- which will allow storing the password in the configuration file. It will not be available in the GUI, as relying on libsecret is far more preferable to this.

Relates to #4 