### PR TITLE
AppImage build improvements

### DIFF
--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     libsecret-1-dev libsecret-1-0 libsecret-common libsecret-tools \
     libtorrent-rasterbar-dev libtorrent-rasterbar2.0t64 \
     libboost-filesystem-dev libboost-filesystem1.83.0 libarchive-tools \
+    gsettings-desktop-schemas-dev gsettings-ubuntu-schemas xdg-desktop-portal-gtk \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/appimage/assets/AppRun
+++ b/appimage/assets/AppRun
@@ -3,6 +3,9 @@
 # Allow app to operate detached from the game directory.
 export APPIMAGE_MODE_ENABLED=1
 
+export GSETTINGS_SCHEMA_DIR="$APPDIR/usr/share/glib-2.0/schemas"
+export GTK_USE_PORTAL=1
+export XDG_CONFIG_HOME="$APPDIR/config"
 export XDG_DATA_DIRS="$APPDIR/usr/share:${XDG_DATA_DIRS:-}"
 export PATH="$APPDIR/usr/bin:${PATH:-}"
 export LD_LIBRARY_PATH="$APPDIR/usr/lib:${LD_LIBRARY_PATH:-}"

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -65,7 +65,12 @@ done
 prepare_dirs() {
   log "Preparing build and tool directories"
   rm -rf "$BUILD_DIR" "$TOOLS_DIR"
-  mkdir -p "$BUILD_DIR" "$TOOLS_DIR" "$APPDIR/usr/bin" "$APPDIR/usr/lib"
+  mkdir -p "$BUILD_DIR" \
+  "$TOOLS_DIR" \
+  "$APPDIR/usr/bin" \
+  "$APPDIR/usr/lib" \
+  "$APPDIR/usr/share/glib-2.0/schemas" \
+  "$APPDIR/config/gtk-4.0"
 }
 
 #========================================
@@ -102,6 +107,7 @@ build_launcher() {
 copy_binaries_and_assets() {
   log "Copying launcher binaries and assets"
   cp "$BUILD_DIR/bin/"* "$APPDIR/usr/bin/"
+  echo "[Settings]" > "$APPDIR/config/gtk-4.0/settings.ini"
   copy_tool() { local tool="$1"; log "Including system tool: $tool"; cp "$(command -v $tool)" "$APPDIR/usr/bin/"; }
   for t in cabextract unzip bsdtar 7z 7za 7zr pzstd unzstd zstd zstdcat zstdgrep zstdless zstdmt sh bash; do copy_tool "$t"; done
   cp -r /usr/lib/7zip "$APPDIR/usr/lib/"


### PR DESCRIPTION
Some improvements to make sure GLIB schemas, GTK schemas and themes were being picked up as well as use a portal for file dialog to make sure we use the native dialog from the system.

This also silences a warning in the console with a stub gtk config file.