### PR TITLE
Stability improvements, free space detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ gui/gtk-assets/*
 !gui/gtk-assets/generate-full-file-manifest.sql
 !gui/gtk-assets/generate-full-file-manifest-count.sql
 !gui/gtk-assets/generate-update-manifest.sql
+!gui/gtk-assets/generate-update-manifest-sz.sql
 !gui/gtk-assets/mylauncher.gresource.xml
 !gui/gtk-assets/styles.css

--- a/README.md
+++ b/README.md
@@ -275,6 +275,14 @@ chmod +x TERA_Launcher_for_Linux-x86_64.AppImage
 
 ---
 
+### How to disable download via Torrent
+
+In some circumstances, torrent downloads may be hindered or blocked on networks hostile to them. To address this, you may use the following ENV toggle to suppress base game file downloads via torrent if the client you are using was configured with it enabled:
+
+```bash
+export TL4L_DISABLE_TORRENT_DOWNLOAD=1
+```
+
 ### Password Storage
 
 By default, this launcher uses **libsecret** to store your account password securely.

--- a/gui/gtk-assets/generate-update-manifest-sz.sql
+++ b/gui/gtk-assets/generate-update-manifest-sz.sql
@@ -1,0 +1,35 @@
+WITH latest_game_version AS (
+    SELECT MAX(version) AS latest_version
+    FROM version_info
+),
+     fs_max AS (
+         SELECT
+             id,
+             MAX(new_ver) AS max_new_ver
+         FROM file_size
+         GROUP BY id
+     ),
+     versioned_files AS (
+         SELECT
+             fi.id,
+             REPLACE(fi.path, '\', '/') AS path,
+             fs.new_ver,
+             fs.size         AS compressed_size,
+             fv.size         AS decompressed_size,
+             fv.hash         AS decompressed_hash
+         FROM file_info fi
+                  JOIN fs_max fsm
+                       ON fi.id = fsm.id
+                  JOIN file_size fs
+                       ON fs.id = fsm.id
+                           AND fs.new_ver = fsm.max_new_ver
+                  JOIN file_version fv
+                       ON fs.id = fv.id
+                           AND fs.new_ver = fv.version
+                  CROSS JOIN latest_game_version lgv
+         WHERE fs.new_ver >= @current_version
+           AND fs.new_ver <= lgv.latest_version
+     )
+SELECT
+    SUM(decompressed_size) AS total_decompressed_size
+FROM versioned_files;

--- a/gui/gtk-assets/mylauncher.gresource.xml
+++ b/gui/gtk-assets/mylauncher.gresource.xml
@@ -27,5 +27,6 @@
         <file>generate-full-file-manifest.sql</file>
         <file>generate-full-file-manifest-count.sql</file>
         <file>generate-update-manifest.sql</file>
+        <file>generate-update-manifest-sz.sql</file>
     </gresource>
 </gresources>

--- a/gui/main.c
+++ b/gui/main.c
@@ -1221,6 +1221,8 @@ static gboolean launcher_init_config(GtkApplication *app) {
   torrent_download_enabled = parse_and_copy_bool(app, launcher_config_json,
                                                  "torrent_download_enabled");
 
+  torrent_download_enabled = !g_getenv("TL4L_DISABLE_TORRENT_DOWNLOAD") ? torrent_download_enabled : false;
+
   json_decref(launcher_config_json);
   return true;
 }

--- a/gui/main.c
+++ b/gui/main.c
@@ -1221,7 +1221,9 @@ static gboolean launcher_init_config(GtkApplication *app) {
   torrent_download_enabled = parse_and_copy_bool(app, launcher_config_json,
                                                  "torrent_download_enabled");
 
-  torrent_download_enabled = !g_getenv("TL4L_DISABLE_TORRENT_DOWNLOAD") ? torrent_download_enabled : false;
+  torrent_download_enabled = !g_getenv("TL4L_DISABLE_TORRENT_DOWNLOAD")
+                                 ? torrent_download_enabled
+                                 : false;
 
   json_decref(launcher_config_json);
   return true;

--- a/gui/main.c
+++ b/gui/main.c
@@ -1577,7 +1577,6 @@ static void start_update_process(LauncherData *ld, bool do_repair) {
   thread_data->window_minimized = false;
   thread_data->window_sensitive = false;
 
-
   // Share patch URL and game path in UpdateData for update functions to do
   // their thing.
   thread_data->update_data.public_patch_url = patch_url_global;

--- a/gui/main.c
+++ b/gui/main.c
@@ -991,6 +991,8 @@ static json_t *load_launcher_config_json(GtkApplication *app,
     if (error) {
       g_error_free(error);
     }
+
+    g_free(launcher_config_gbytes);
     return nullptr;
   }
 
@@ -1003,12 +1005,16 @@ static json_t *load_launcher_config_json(GtkApplication *app,
     if (error) {
       g_error_free(error);
     }
+
+    g_free(launcher_config_gbytes);
     return nullptr;
   }
 
   if (error) {
     g_error_free(error);
   }
+
+  g_free(launcher_config_gbytes);
   return config_json;
 }
 
@@ -1363,6 +1369,7 @@ static gpointer update_thread_func(gpointer data) {
 
   UpdateData *update_data = &ut_data->update_data;
   ut_data->window_minimized = false;
+  ut_data = ut_data_ref(ut_data);
 
   char binaries_test_path[FIXED_STRING_FIELD_SZ];
   size_t required;
@@ -1491,6 +1498,7 @@ static gpointer update_thread_func(gpointer data) {
                     ut_data_ref(ut_data), (GDestroyNotify)ut_data_unref);
     g_idle_add_full(G_PRIORITY_HIGH_IDLE, button_status_callback,
                     ut_data_ref(ut_data), (GDestroyNotify)ut_data_unref);
+    ut_data_unref(ut_data);
     return nullptr;
   }
 
@@ -1503,6 +1511,7 @@ static gpointer update_thread_func(gpointer data) {
     g_idle_add_full(G_PRIORITY_HIGH_IDLE, button_status_callback,
                     ut_data_ref(ut_data), (GDestroyNotify)ut_data_unref);
     g_list_free_full(files_to_update, free_file_info);
+    ut_data_unref(ut_data);
     return nullptr;
   }
 
@@ -1514,6 +1523,7 @@ static gpointer update_thread_func(gpointer data) {
   ut_data->repair_button_enabled = TRUE;
   g_idle_add_full(G_PRIORITY_HIGH_IDLE, button_status_callback,
                   ut_data_ref(ut_data), (GDestroyNotify)ut_data_unref);
+  ut_data_unref(ut_data);
   return nullptr;
 }
 
@@ -1555,6 +1565,14 @@ static void start_update_process(LauncherData *ld, bool do_repair) {
     gtk_widget_set_sensitive(ld->play_btn, TRUE);
     return;
   }
+
+  memset(thread_data, 0, sizeof(UpdateThreadData));
+  thread_data->play_button_enabled = false;
+  thread_data->repair_button_enabled = false;
+  thread_data->enable_pulse = false;
+  thread_data->window_minimized = false;
+  thread_data->window_sensitive = false;
+
 
   // Share patch URL and game path in UpdateData for update functions to do
   // their thing.

--- a/gui/options_dialog.c
+++ b/gui/options_dialog.c
@@ -69,7 +69,11 @@ bool validate_wine_dir(const char *path) {
  * @return true if gamemoderun is found in the system path, false otherwise.
  */
 bool check_gamemode_available(void) {
-  return g_find_program_in_path("gamemoderun") != nullptr;
+  char *path = g_find_program_in_path("gamemoderun");
+  bool retval = path != nullptr;
+  if (path)
+    g_free(path);
+  return retval;
 }
 
 /**
@@ -78,7 +82,11 @@ bool check_gamemode_available(void) {
  * @return true if gamescope is found in the system path, false otherwise.
  */
 bool check_gamescope_available(void) {
-  return g_find_program_in_path("gamescope") != nullptr;
+  char *path = g_find_program_in_path("gamescope");
+  bool retval = path != nullptr;
+  if (path)
+    g_free(path);
+  return retval;
 }
 
 /**

--- a/gui/torrent_wrapper.h
+++ b/gui/torrent_wrapper.h
@@ -67,6 +67,22 @@ int torrent_session_start_download(TorrentSession *session,
                                    const char *save_path);
 
 /**
+ * @brief Retrieve the total size of the torrent contents (in bytes) by fetching
+ * metadata.
+ *
+ * Parses the magnet URI, fetches metadata (blocking), and returns the total
+ * content size.
+ *
+ * @param session     Pointer to a valid TorrentSession.
+ * @param magnet_link Null-terminated string containing the magnet URI.
+ * @param size_out    Pointer to uint64_t to receive the total size in bytes.
+ * @return 0 on success, or -1 on error. Check torrent_session_get_error() for
+ * details on failure.
+ */
+int torrent_session_get_total_size(TorrentSession *session,
+                                   const char *magnet_link, uint64_t *size_out);
+
+/**
  * @brief Close and clean up a torrent session.
  *
  * Signals the download thread to stop, waits for it to finish,

--- a/gui/updater.c
+++ b/gui/updater.c
@@ -43,6 +43,11 @@ static gchar *patch_path = nullptr;
 static const gchar *sql_generate_update_manifest = nullptr;
 static GBytes *generate_update_manifest_gbytes = nullptr;
 
+/* SQL query to generate the update manifest.
+   Note: The @current_version placeholder is bound in the code. */
+static const gchar *sql_generate_update_manifest_sz = nullptr;
+static GBytes *generate_update_manifest_sz_gbytes = nullptr;
+
 /* SQL query to generate a full file manifest (used for repair operations) */
 static const gchar *sql_generate_full_manifest = nullptr;
 static GBytes *generate_full_file_manifest_gbytes = nullptr;
@@ -849,6 +854,12 @@ void updater_init() {
     g_error("Error loading SQL resource: %s", error->message);
   }
 
+  generate_update_manifest_sz_gbytes = g_resources_lookup_data(
+      "/com/tera/launcher/generate-update-manifest-sz.sql", 0, &error);
+  if (!generate_update_manifest_sz_gbytes) {
+    g_error("Error loading SQL resource: %s", error->message);
+  }
+
   generate_full_file_manifest_count_gbytes = g_resources_lookup_data(
       "/com/tera/launcher/generate-full-file-manifest-count.sql", 0, &error);
   if (!generate_full_file_manifest_count_gbytes) {
@@ -870,6 +881,12 @@ void updater_init() {
   sql_generate_update_manifest =
       g_bytes_get_data(generate_update_manifest_gbytes, &size);
   if (!sql_generate_update_manifest) {
+    g_error("Could not get update manifest query data from resource.");
+  }
+
+  sql_generate_update_manifest_sz =
+      g_bytes_get_data(generate_update_manifest_sz_gbytes, &size);
+  if (!sql_generate_update_manifest_sz) {
     g_error("Could not get update manifest query data from resource.");
   }
 

--- a/gui/updater.c
+++ b/gui/updater.c
@@ -569,7 +569,7 @@ gboolean extract_torrent_base_files(ProgressCallback overall_cb,
   g_main_loop_run(d->loop);
 
   g_main_loop_unref(d->loop);
-  gboolean retval = d->success;
+  const gboolean retval = d->success;
   g_free(archive_path);
   g_free(d);
 
@@ -605,7 +605,7 @@ static gboolean download_version_ini(UpdateData *data) {
     if (!g_file_delete(dest_file, nullptr, &error)) {
       g_printerr(
           "Unable to delete the old version.ini while fetching the new one.");
-      g_error_free(error);
+      g_clear_error(&error);
       g_object_unref(src_file);
       g_object_unref(dest_file);
       g_free(dest_path);
@@ -618,7 +618,7 @@ static gboolean download_version_ini(UpdateData *data) {
   if (!g_file_move(src_file, dest_file, G_FILE_COPY_NONE, nullptr, nullptr,
                    nullptr, &error)) {
     g_printerr("Failed to move version.ini to game path: %s\n", error->message);
-    g_error_free(error);
+    g_clear_error(&error);
     g_object_unref(src_file);
     g_object_unref(dest_file);
     return FALSE;
@@ -785,7 +785,8 @@ static gboolean parse_version_ini() {
     strcpy(ini_path, "version.ini");
   }
 
-  if (!g_key_file_load_from_file(key_file, ini_path, G_KEY_FILE_NONE, nullptr)) {
+  if (!g_key_file_load_from_file(key_file, ini_path, G_KEY_FILE_NONE,
+                                 nullptr)) {
     g_object_unref(key_file);
     return FALSE;
   }
@@ -1263,7 +1264,7 @@ gboolean download_all_files(UpdateData *data, GList *files_to_update,
     if (!g_file_move(src_file, dest_file, G_FILE_COPY_NONE, nullptr, nullptr,
                      nullptr, &error)) {
       g_printerr("Failed to move file to destination: %s\n", info->path);
-      g_error_free(error);
+      g_clear_error(&error);
       unlink(temp_extract);
       overall_success = FALSE;
     }


### PR DESCRIPTION
This PR addresses a variety of issues

- Free space detection at various stages of download and extraction and will reject out of update/repair/etc if there is not enough space.
- Allow torrent downloads to be suppressed in environments that simply don't allow them to work using an ENV as a flag.
- Fixup various memory management mishaps that caused subtle crashes due to invalid read/writes/frees/etc.
- Fix an issue with the AppImage where on first run of the launcher after the game is set up, the wine base directory is unpopulated, causing the launcher to both fail to launch the game, but eventually segfault due to invalid access issues
- Various refactoring