### PR TITLE
Add Nix flake

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://spec.editorconfig.org#supported-pairs
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.{nix,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc="
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ gui/gtk-assets/*
 !gui/gtk-assets/generate-update-manifest-sz.sql
 !gui/gtk-assets/mylauncher.gresource.xml
 !gui/gtk-assets/styles.css
+
+result
+result/
+
+.direnv/
+.idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A community-created Linux launcher for TERA Online. This project is a **port** (
 
 To build and run this launcher natively, you will need:
 
+* **just** command runner
 * **CMake** (version 3.16 or later)
 * A **C compiler** (e.g., `gcc`) and build tools (such as `make`)
 * **winegcc** (for building the stub‑launcher component)
@@ -58,13 +59,55 @@ To build and run this launcher natively, you will need:
 * **Boost** development libraries (at least `system` and `filesystem` components)
 * An internet connection (for asset fetching)
 
+An optional Nix shell with all dependencies is provided. The shell adds build executables to `PATH` (e.g., `gcc`, `cmake`) and development libraries to CMake env vars (e.g., `CMAKE_LIBRARY_PATH`, `CMAKE_INCLUDE_PATH`) automatically.
+
+Install Nix with the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer).
+
+The Nix shell subprocess can be started with `nix develop`.
+
+Alternatively, install [direnv](https://direnv.net/#basic-installation) to automatically load and unload the Nix shell variables in your current shell when `cd`-ing in and out of the project (with its shell hook) or when opening a project in editors (with its [editor integration](https://github.com/direnv/direnv/wiki#editor-integration)).
+
 This has been tested to build on:
 
+* Nix shell on most Linux distributions
 * Ubuntu 24.04 LTS
 * Fedora 42 Workstation
 * Arch Linux
 
 > **Note:** If you only intend to build via **AppImage Mode**, you do **not** need to install these host dependencies locally— the Docker container provides all necessary tools and libraries.
+
+### Nix Shell
+
+Without direnv:
+
+```bash
+# clone
+git clone https://github.com/PopusBenedictus/tera-launcher-for-linux.git
+
+cd tera-launcher-for-linux
+
+# start Nix Bash subshell
+nix develop
+
+# develop
+
+# ctrl + D to exit Nix Bash subshell
+```
+
+With direnv:
+
+```bash
+# clone
+git clone https://github.com/PopusBenedictus/tera-launcher-for-linux.git
+
+# direnv applies Nix shell env vars to current shell (no subprocess)
+cd tera-launcher-for-linux
+
+# develop
+
+# direnv unloads Nix shell env vars
+cd ..
+```
 
 ### Ubuntu/Debian‑based
 
@@ -182,19 +225,10 @@ Follow the original CMake-based instructions:
    # edit launcher-config.json as needed
    ```
 
-2. **Create** a build directory and run CMake:
+2. **Build**:
 
    ```bash
-   mkdir build && cd build
-   cmake ..
-   # or with custom config:
-   # cmake .. -DCUSTOM_CONFIG_PATH="/path/to/launcher-config.json"
-   ```
-
-3. **Build**:
-
-   ```bash
-   cmake --build .
+   just build
    ```
 
 ---

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-appimage": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749006067,
+        "narHash": "sha256-rSwndd+4JmGrjR/APDTgJlXTEPwfCmt7UF+SceW3bfM=",
+        "owner": "ralismark",
+        "repo": "nix-appimage",
+        "rev": "5dadbcd9f0da9adc49d6d831d5c2eab0bbfdae67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ralismark",
+        "ref": "main",
+        "repo": "nix-appimage",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-appimage": "nix-appimage",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,143 @@
+# https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake#flake-format
+# https://wiki.nixos.org/wiki/Flakes#Flake_schema
+{
+  inputs = {
+    # https://nixos.org/manual/nixpkgs/unstable
+    # https://search.nixos.org/packages?channel=unstable
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nix-appimage.url = "github:ralismark/nix-appimage/main";
+    # https://github.com/ralismark/nix-appimage
+    nix-appimage.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix-appimage,
+    }:
+    let
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      genSystemAttrs = f: nixpkgs.lib.genAttrs systems f;
+    in
+    {
+      # "nix build .#<attribute>"
+      packages = genSystemAttrs (system: {
+        default = self.packages.${system}.tera-launcher-for-linux;
+
+        easylzma =
+          with nixpkgs.legacyPackages.${system};
+          stdenv.mkDerivation (finalAttrs: {
+            pname = "easylzma";
+            version = "0.0.9";
+
+            src = fetchFromGitHub {
+              owner = "PopusBenedictus";
+              repo = "easylzma";
+              rev = "master";
+              hash = "sha256-FddX1Zpb3tlUAVSHfuQ+U2kevWNAWPxtWxbA8G/GHuM=";
+            };
+
+            strictDeps = true;
+
+            nativeBuildInputs = [
+              cmake
+            ];
+
+            installPhase = ''
+              mkdir $out
+              cp -r ${finalAttrs.pname}-${finalAttrs.version}/* $out
+            '';
+
+            meta = {
+              description = "An easy to use, tiny, public domain, C wrapper library around Igor Pavlov's work that can be used to compress and extract lzma files";
+              homepage = "https://github.com/PopusBenedictus/easylzma";
+              license = lib.licenses.publicDomain;
+              mainProgram = "elzma";
+            };
+          });
+
+        # TODO: Fix build in Nix sandbox (move network access stuff to fixed output derivation/package)
+        #
+        # https://bmcgee.ie/posts/2023/02/nix-what-are-fixed-output-derivations-and-why-use-them
+        tera-launcher-for-linux =
+          with nixpkgs.legacyPackages.${system};
+          stdenv.mkDerivation (finalAttrs: {
+            pname = "tera-launcher-for-linux";
+            version = "2025.04.11";
+
+            src = lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                ./gui
+                ./stub
+                ./utils
+                ./CMakeLists.txt
+              ];
+            };
+
+            strictDeps = true;
+
+            nativeBuildInputs = [
+              cmake
+              libarchive
+              pkg-config
+              python3
+              wineWowPackages.stableFull
+              winetricks
+            ];
+
+            buildInputs = [
+              boost.dev
+              curl.dev
+              gtk4.dev
+              jansson.dev
+              libsecret.dev
+              libtorrent-rasterbar.dev
+              minixml
+              openssl.dev
+              protobufc.dev
+              sqlite.dev
+              # TODO: Fix build to source with find_package instead of ExternalProject_Add
+              self.packages.${system}.easylzma
+            ];
+
+            meta = {
+              description = "A community-created Linux launcher for TERA Online";
+              homepage = "https://github.com/PopusBenedictus/tera-launcher-for-linux";
+              license = lib.licenses.wtfpl;
+              mainProgram = finalAttrs.pname;
+            };
+          });
+
+        tera-launcher-for-linux-appimage =
+          nix-appimage.bundlers.${system}.default
+            self.packages.${system}.tera-launcher-for-linux;
+      });
+
+      # "nix develop"/"direnv allow"
+      devShells = genSystemAttrs (system: {
+        default = nixpkgs.legacyPackages.${system}.mkShell {
+          packages = with nixpkgs.legacyPackages.${system}; [
+            nix
+            nix-update
+            git
+            git-lfs
+            just
+            treefmt
+            nixfmt-rfc-style
+            clang-tools
+          ];
+
+          # TODO: Remove when build fixed in Nix sandbox
+          inputsFrom = with self.packages.${system}; [
+            tera-launcher-for-linux
+          ];
+        };
+      });
+    };
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+# https://just.systems/man/en
+
+# show recipes
+help:
+    just --list
+
+# format files
+format:
+    treefmt
+
+# build everything
+build:
+    rm -rf build
+    cmake -B build
+    make -C build

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,18 @@
+# https://treefmt.com/latest/getting-started/configure
+[formatter.clang-format]
+command = "clang-format"
+includes = [
+    "*.c",
+    "*.cc",
+    "*.cpp",
+    "*.h",
+    "*.hh",
+    "*.hpp"
+]
+options = ["-i"]
+
+[formatter.nixfmt]
+command = "nixfmt"
+includes = [
+    "*.nix"
+]


### PR DESCRIPTION
Add dev shell and reproducible builds.

**To-Do**

- source easylzma from Nix derivation/package in the flake
- move launcher asset fetch to a fixed output derivation/package in the flake
   - network access is blocked in the Nix sandbox for non-fixed-output derivations
- test nix-appimage to turn the launcher derivation/package into an app image