### PR TITLE
Enhancements to support Shinra Meter with Tera Toolbox

### DIFF
--- a/gui/gtk-assets/launcher-config.json
+++ b/gui/gtk-assets/launcher-config.json
@@ -10,6 +10,10 @@
   "torrent_prefix_name": ".terastarscape/torrent",
   "torrent_magnet_link": "magnet:?xt=urn:btih:RHBA7LDWYCWIQDBBGN7PZBBEMZWVLA7X&dn=TERA%20Starscape.zip&xl=63357892348&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce",
   "torrent_payload_file_name": "TERA Starscape.zip",
+  "x86_dotnet_runtime_url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/5.0.17/windowsdesktop-runtime-5.0.17-win-x86.exe",
+  "x86_dotnet_runtime_hash": "74a379323e52172f563cd996880f58d58a19303ae59b3f55ff52625dfe8a4a602609785b1174b38f2da97282f90f1ade53194354f48773512943eae249926ee8",
+  "x64_dotnet_runtime_url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/5.0.17/windowsdesktop-runtime-5.0.17-win-x64.exe",
+  "x64_dotnet_runtime_hash": "f7eb69a953ff6346a180e5200075120b4b47cb89a75bc36c76a9e468c037bb2376f497dbf8e0bada152bc3ec35dceaad55d0a811586569575bf5b201d1e32baf",
   "game_lang": "EUR",
   "public_launcher_assets": [
     "bg.jpg",

--- a/gui/main.c
+++ b/gui/main.c
@@ -604,7 +604,8 @@ gchar *download_file_to_temp(const gchar *url, GError **error) {
 static gpointer download_temp_thread(gpointer user_data) {
   AsyncDownload *job = user_data;
 
-  g_atomic_pointer_set(&job->filename, download_file_to_temp(job->url, &job->error));
+  g_atomic_pointer_set(&job->filename,
+                       download_file_to_temp(job->url, &job->error));
   if (job->filename && job->expected_hash) {
     if (!validate_file_checksum(job->filename, job->expected_hash,
                                 &job->error)) {

--- a/gui/main.c
+++ b/gui/main.c
@@ -281,6 +281,12 @@ bool plaintext_login_info_storage = false;
 bool torrent_download_enabled = false;
 
 /**
+ * @brief If set to TRUE, indicates that curl has already been initialized by a
+ * function and should not be initialized again.
+ */
+bool curl_inited = false;
+
+/**
  * @brief Used to store the final update thread message, if any, to update
  * progress bar label when the update resources are being thrown out.
  */
@@ -801,6 +807,11 @@ void download_file_to_temp_async_free(AsyncDownload *job) {
  */
 static bool do_login(const char *username, const char *password,
                      LoginData *out) {
+  if (!curl_inited) {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    curl_inited = true;
+  }
+
   CURL *curl = curl_easy_init();
   if (!curl) {
     g_warning("Failed to initialize cURL");

--- a/gui/main.c
+++ b/gui/main.c
@@ -63,6 +63,8 @@ typedef struct {
   gboolean window_sensitive;
   gboolean wine_env_setup_done;
   gboolean wine_env_setup_success;
+  gint dotnet_setup_done_count;
+  gboolean dotnet_setup_success;
 } UpdateThreadData;
 
 /**

--- a/gui/main.c
+++ b/gui/main.c
@@ -2296,10 +2296,12 @@ static void game_wine_env_thread_watcher(GPid pid, gint wait_status,
  * @brief Prepare wineprefix if it does not exist and install dependencies.
  *
  * @param envp Environment variables to use when launching winetricks.
+ * @param wine_bin Path to the wine binary.
  * @param thread_data Update thread struct for GUI updates while performing the
  * task.
  */
-static bool prepare_wineprefix(gchar **envp, UpdateThreadData *thread_data) {
+static bool prepare_wineprefix(gchar **envp, gchar *wine_bin,
+                               UpdateThreadData *thread_data) {
   gchar *winetricks = g_find_program_in_path("winetricks");
   if (!winetricks) {
     g_warning("Failed to find winetricks");
@@ -2546,7 +2548,7 @@ static gpointer game_launcher_thread(gpointer data) {
   GError *err = nullptr;
   gint status = 0;
 
-  if (!prepare_wineprefix(envp, thread_data)) {
+  if (!prepare_wineprefix(envp, wine_bin, thread_data)) {
     thread_data->current_progress = 0.0;
     thread_data->current_message = "Failed to Launch Game";
     thread_data->current_download_progress = 1.0;

--- a/gui/main.c
+++ b/gui/main.c
@@ -214,6 +214,28 @@ char tera_toolbox_path_global[FIXED_STRING_FIELD_SZ] = {0};
 char gamescope_args_global[FIXED_STRING_FIELD_SZ] = {0};
 
 /**
+ * @brief Download URL for the x86 dotnet runtime required for Shinra Meter.
+ */
+char dotnet_download_url_x86_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
+ * @brief SHA-512 validation hash for the x86 dotnet runtime required for Shinra
+ * Meter.
+ */
+char dotnet_download_hash_x86_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
+ * @brief Download URL for the x64 dotnet runtime required for Shinra Meter.
+ */
+char dotnet_download_url_x64_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
+ * @brief SHA-512 validation hash for the x64 dotnet runtime required for Shinra
+ * Meter.
+ */
+char dotnet_download_hash_x64_global[FIXED_STRING_FIELD_SZ] = {0};
+
+/**
  * @brief If set to TRUE, attempt to launch TERA Online using Feral Game Mode.
  * Turned off by default.
  */
@@ -1580,6 +1602,15 @@ static gboolean launcher_init_config(GtkApplication *app) {
                         game_lang_global);
   parse_and_copy_string(app, launcher_config_json, "service_name",
                         service_name_global);
+
+  parse_and_copy_string(app, launcher_config_json, "x86_dotnet_runtime_url",
+                        dotnet_download_url_x86_global);
+  parse_and_copy_string(app, launcher_config_json, "x86_dotnet_runtime_hash",
+                        dotnet_download_hash_x86_global);
+  parse_and_copy_string(app, launcher_config_json, "x64_dotnet_runtime_url",
+                        dotnet_download_url_x64_global);
+  parse_and_copy_string(app, launcher_config_json, "x64_dotnet_runtime_hash",
+                        dotnet_download_hash_x64_global);
 
   torrent_download_enabled = parse_and_copy_bool(app, launcher_config_json,
                                                  "torrent_download_enabled");

--- a/gui/main.c
+++ b/gui/main.c
@@ -2448,6 +2448,7 @@ static gpointer game_launcher_thread(gpointer data) {
   thread_data->window_minimized = false;
   thread_data->wine_env_setup_done = false;
   thread_data->wine_env_setup_success = false;
+  thread_data->dotnet_setup_success = false;
   thread_data->update_data.download_progress_bar =
       GTK_PROGRESS_BAR(launch_data->ld->update_repair_download_bar);
   thread_data->update_data.progress_bar =

--- a/gui/main.c
+++ b/gui/main.c
@@ -2343,7 +2343,7 @@ static bool prepare_wineprefix(gchar **envp, gchar *wine_bin,
 
   GError *err = nullptr;
   GPid child_pid = 0;
-  const gboolean ok =
+  gboolean ok =
       g_spawn_async(nullptr, argv_complete, envp, G_SPAWN_DO_NOT_REAP_CHILD,
                     nullptr, nullptr, &child_pid, &err);
 


### PR DESCRIPTION
Shinra Meter requires the windows dotnet runtime to be installed (and typically a specific version of it that might vary depending on the version of Tera Toolbox users are using).

Add support to fetch and install this runtime. Additionally, add in a workaround to disable the use of libicu per #36 which we will address as part of the refactoring project later.

These changes combined should permit TeraToolbox to _generally_ work. Note that, because the dotnet runtime that might be required may vary depending on the server the launcher is coupled with and what they permit, a different runtime might be required. Ergo, additional launcher-config.json options have been added (with defaults populated).